### PR TITLE
fix: hide docsearch main category titles

### DIFF
--- a/src/less/main.less
+++ b/src/less/main.less
@@ -43,6 +43,7 @@
   text-transform: uppercase;
   color: #3a59f0;
   font-size: 0.9em;
+  display: none !important;
 }
 
 .algolia-docsearch-suggestion.algolia-docsearch-suggestion__secondary .algolia-docsearch-suggestion--subcategory-column {


### PR DESCRIPTION
PTAL