### PR TITLE
robots.txt: Disallow user agent to crawl some pages

### DIFF
--- a/layouts/page/index.html
+++ b/layouts/page/index.html
@@ -26,7 +26,7 @@
                   <p>5</p>
                 </div>
                 <div class="numb">
-                  <p>6</p>
+                  <p>8</p>
                 </div>
             </div>
             <div class="buttons-en">

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,1 +1,11 @@
 Sitemap: https://pingcap.com/sitemap.xml
+
+# Disallow agent to crawl earlier versions of docs/doc-cn
+# Disallow url must end with /
+User-agent: *
+Disallow: /docs/v1.0/
+Disallow: /docs/v2.0/
+Disallow: /docs/v2.1/
+Disallow: /docs-cn/v1.0/
+Disallow: /docs-cn/v2.0/
+Disallow: /docs-cn/v2.1/


### PR DESCRIPTION
Disallow user agent to crawl pages start with earlier versions of docs/docs-cn