### PR TITLE
Remove purposeless site-index page

### DIFF
--- a/content/site-index.md
+++ b/content/site-index.md
@@ -1,4 +1,0 @@
----
-type: page
-layout: site-index
----

--- a/layouts/page/site-index.html
+++ b/layouts/page/site-index.html
@@ -1,4 +1,0 @@
-[{{ range $index, $page := .Site.Pages }}{{ if $page.Title }}{{ if $index }},{{ end }}
-		{"url": "{{ $page.Permalink }}",
-		"title": "{{ $page.Title }}", {{$str := (replaceRE "[\n\\\\]" "" $page.Plain) }}
-		"content": "{{ $str | truncate 8000 }}"}{{ end }}{{ end }}]


### PR DESCRIPTION
Due to encoding errors, this `site-index` page isn't able to be parsed by Google search console. (We have Chinese characters and are presenting a USASCII encoding.)

Since this page appears to have no real purpose (there is a `site-map.xml` which is the correct thing), this PR just removes it.

![image](https://user-images.githubusercontent.com/130903/62314629-5187a580-b448-11e9-99ce-61905b6beabd.png)
