### PR TITLE
deploy website to a backup aws server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,11 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "src" ]; then
               ssh-keyscan "${DEPLOY_HOST}" >> ~/.ssh/known_hosts 2>/dev/null;
-              echo "${DEPLOY_PATH}";
               rsync -avz --delete dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}" || true;
               ssh-keyscan "${DEPLOY_AWS_HOST}" >> ~/.ssh/known_hosts 2>/dev/null;
               rsync -avz --delete dist/ "${DEPLOY_AWS_USER}@${DEPLOY_AWS_HOST}:${DEPLOY_AWS_PATH}" || true;
+              ssh-keyscan "${DEPLOY_AWS_HOST_BACK_UP}" >> ~/.ssh/known_hosts 2>/dev/null;
+              rsync -avz --delete dist/ "${DEPLOY_AWS_USER}@${DEPLOY_AWS_HOST_BACK_UP}:${DEPLOY_AWS_PATH}" || true;
               curl "http://www.google.com/ping?sitemap=https://pingcap.com/sitemap.xml"
             fi
 


### PR DESCRIPTION
The website path (DEPLOY_AWS_PATH) and DEPLOY_AWS_USER are the same with the one on the existing AWS serve, so I only setup the new server-host (DEPLOY_AWS_HOST_BACK_UP) on CI config and reuse the path and user variables. PTAL