### PR TITLE
ui: disable add remote sql widget

### DIFF
--- a/components/pages/Dashboard/EditingLayer.tsx
+++ b/components/pages/Dashboard/EditingLayer.tsx
@@ -21,11 +21,12 @@ export interface EditLayerProps {
   id: string;
   movable?: boolean;
 
+  deletable?: boolean;
   onDelete: () => void;
   DeleteIcon: ComponentType<SVGAttributes<SVGSVGElement>>
 }
 
-export function EditingLayer ({ id, movable = true, onDelete, DeleteIcon }: EditLayerProps) {
+export function EditingLayer ({ id, movable = true, deletable = true, onDelete, DeleteIcon }: EditLayerProps) {
   const router = useRouter();
   const { name, isPrivate } = useLibraryItemField(id, ({ name, visibility }) => ({
     name,
@@ -78,12 +79,12 @@ export function EditingLayer ({ id, movable = true, onDelete, DeleteIcon }: Edit
           data-layer-item
           items={(
             <>
-              <MenuItem
+              {deletable && (<MenuItem
                 id="delete"
                 text={<DeleteIcon className="text-red-500" />}
                 action={onDelete}
                 order={10000}
-              />
+              />)}
               {authenticated && duplicable && (
                 <MenuItem
                   id="duplicate"

--- a/components/pages/List/Item.tsx
+++ b/components/pages/List/Item.tsx
@@ -4,6 +4,7 @@ import WidgetPreview from '@/components/WidgetPreview';
 import LoadingIndicator from '@/packages/ui/components/loading-indicator/Icon';
 import dashboards from '@/store/features/dashboards';
 import library from '@/store/features/library';
+import { useWidget } from '@/store/features/widgets';
 import { LibraryItem } from '@/utils/types/config';
 import TrashIcon from 'bootstrap-icons/icons/trash.svg';
 import { Suspense, useCallback } from 'react';
@@ -12,6 +13,8 @@ import { useDispatch } from 'react-redux';
 export default function Item ({ item: { name, id, props: { showBorder, ...props }, referencedDashboards = [] } }: { item: LibraryItem }) {
   const dispatch = useDispatch();
   const confirm = useConfirm();
+
+  const widget = useWidget(name);
 
   const deleteLibraryItem = useCallback((id: string) => {
     confirm({
@@ -56,6 +59,7 @@ export default function Item ({ item: { name, id, props: { showBorder, ...props 
           <EditingLayer
             id={id ?? name}
             movable={false}
+            deletable={widget.deletable !== false}
             onDelete={() => handleDelete(id ?? name)}
             DeleteIcon={TrashIcon}
           />

--- a/core/widgets-manifest.ts
+++ b/core/widgets-manifest.ts
@@ -12,6 +12,7 @@ type WidgetModuleMeta<P = any> = {
   duplicable?: boolean,
   styleConfigurable?: ConfigurableStyle[],
   shareable?: boolean;
+  deletable?: boolean;
   /** @deprecated */
   configurablePropsOverwrite?: Partial<P>,
   /** @deprecated */

--- a/packages/widgets/src/widgets/db/sql/remote/index.ts
+++ b/packages/widgets/src/widgets/db/sql/remote/index.ts
@@ -1,6 +1,6 @@
 export const Widget = () => import('./Widget');
 
-export const ConfigureComponent = () => import('./ConfigureComponent');
+// export const ConfigureComponent = () => import('./ConfigureComponent');
 
 export const Icon = () => import('./Icon');
 
@@ -20,7 +20,8 @@ export const defaultProps = {
 export const styleConfigurable = ['showBorder'];
 
 export const shareable = true;
-export const duplicable = true;
+// export const duplicable = true;
+export const deletable = false;
 
 export const category = 'SQL';
 export const displayName = 'Remote SQL Chart';


### PR DESCRIPTION
- remove `remote sql chart` button in `add widget`
- disable delete remote sql chart in admin
- disable edit remote sql chart in dashboard