### PR TITLE
fix(#127): add default error boundary to widgets

### DIFF
--- a/app/@modal/(all)/(.)query-my-database/page.tsx
+++ b/app/@modal/(all)/(.)query-my-database/page.tsx
@@ -5,3 +5,5 @@ export default function () {
     <TiDBCloudPlayground />
   );
 }
+
+export const dynamic = 'force-dynamic';

--- a/components/WidgetPreview/WidgetPreview.tsx
+++ b/components/WidgetPreview/WidgetPreview.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useDataOptions } from '@/components/pages/Dashboard/dataOptions';
+import { ErrorBoundary } from '@/packages/ui/components/error-boundary';
 import WidgetContext from '@/packages/ui/context/widget';
 import { useResolvedWidget } from '@/store/features/widgets';
 import clientOnly from '@/utils/clientOnly';
@@ -38,12 +39,14 @@ function WidgetPreview ({ id, name, className, onClick, noTitle = false, props, 
           creating: false,
           ...dataOptions,
         }}>
-          <Widget
-            {...props}
-            {...widget.widgetListItemPropsOverwrite}
-            className={clsx('flex-1', props.className, widget.widgetListItemPropsOverwrite?.className, className)}
-            ref={visibleRef}
-          />
+          <ErrorBoundary>
+            <Widget
+              {...props}
+              {...widget.widgetListItemPropsOverwrite}
+              className={clsx('flex-1', props.className, widget.widgetListItemPropsOverwrite?.className, className)}
+              ref={visibleRef}
+            />
+          </ErrorBoundary>
         </WidgetContext.Provider>
       </div>
     </>

--- a/components/pages/Dashboard/createWidgetComponent.tsx
+++ b/components/pages/Dashboard/createWidgetComponent.tsx
@@ -4,7 +4,6 @@ import ExploreLayer from '@/components/pages/Dashboard/ExploreLayer';
 import useRefCallback from '@/packages/ui/hooks/ref-callback';
 import { useDeleteDashboardItem } from '@/store/features/dashboards';
 import { useLibraryItemField } from '@/store/features/library';
-import { useWidget } from '@/store/features/widgets';
 import CloseIcon from 'bootstrap-icons/icons/x.svg';
 import clsx from 'clsx';
 import { forwardRef, ReactElement, useContext } from 'react';

--- a/packages/ui/components/error-boundary/ErrorBoundary.tsx
+++ b/packages/ui/components/error-boundary/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { Component, ComponentType, ErrorInfo, FC, ReactNode, useMemo } from 'react';
+import { Alert } from '../../../../components/Alert';
+import { getErrorInfo } from '../../utils/error.ts';
+
+export interface ErrorComponentProps {
+  error: unknown;
+  errorInfo: ErrorInfo;
+}
+
+export interface ErrorBoundaryProps {
+  errorComponent?: ComponentType<ErrorComponentProps>;
+  children: ReactNode;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, { errorProps?: ErrorComponentProps }> {
+  constructor (props) {
+    super(props);
+    this.state = { errorProps: undefined }
+  }
+
+  componentDidCatch (error: Error, errorInfo: React.ErrorInfo) {
+    this.setState({
+      errorProps: {
+        error,
+        errorInfo,
+      },
+    });
+  }
+
+  render () {
+    if (this.state.errorProps) {
+      const { errorComponent: EC = DefaultErrorAlert } = this.props;
+      return <EC {...this.state.errorProps} />;
+    } else {
+      return this.props.children;
+    }
+  }
+}
+
+const DefaultErrorAlert: FC<ErrorComponentProps> = ({ error }) => {
+  const { title, message } = useMemo(() => {
+    return getErrorInfo(error);
+  }, [error]);
+
+  return <Alert type="error" title={title} message={message} />;
+};

--- a/packages/ui/components/error-boundary/ErrorBoundary.tsx
+++ b/packages/ui/components/error-boundary/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ComponentType, ErrorInfo, FC, ReactNode, useMemo } from 'react';
 import { Alert } from '../../../../components/Alert';
-import { getErrorInfo } from '../../utils/error.ts';
+import { getErrorInfo } from '../../utils/error';
 
 export interface ErrorComponentProps {
   error: unknown;
@@ -13,12 +13,12 @@ export interface ErrorBoundaryProps {
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, { errorProps?: ErrorComponentProps }> {
-  constructor (props) {
+  constructor (props: ErrorBoundaryProps) {
     super(props);
     this.state = { errorProps: undefined }
   }
 
-  componentDidCatch (error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch (error: Error, errorInfo: ErrorInfo) {
     this.setState({
       errorProps: {
         error,

--- a/packages/ui/components/error-boundary/index.ts
+++ b/packages/ui/components/error-boundary/index.ts
@@ -1,0 +1,1 @@
+export * from './ErrorBoundary';

--- a/packages/ui/utils/error.ts
+++ b/packages/ui/utils/error.ts
@@ -1,0 +1,24 @@
+export function getErrorInfo (error: unknown) {
+  let message: string
+  let title: string | undefined
+  if (error) {
+    if (typeof error === 'object') {
+      if ('message' in error) {
+        message = String(error.message)
+      }else {
+        message = error.toString()
+      }
+      if ('title' in error) {
+        title = String(error.title)
+      } else if ('type' in error) {
+        title = String(error.type)
+      }
+    } else {
+      message = String(error)
+    }
+  } else {
+    message = 'No message'
+  }
+
+  return { title, message }
+}

--- a/packages/ui/utils/suspense.tsx
+++ b/packages/ui/utils/suspense.tsx
@@ -1,10 +1,13 @@
-import { FC, ForwardedRef, forwardRef, ReactNode, RefAttributes, Suspense } from 'react';
+import { ErrorBoundary, ErrorComponentProps } from '@/packages/ui/components/error-boundary';
+import { ComponentType, FC, ForwardedRef, forwardRef, ReactNode, RefAttributes, Suspense } from 'react';
 
-export function withSuspense<T, P> (Component: FC<P> & RefAttributes<T>, fallback?: (ref: ForwardedRef<T>) => ReactNode) {
+export function withSuspense<T, P> (Component: FC<P> & RefAttributes<T>, fallback?: (ref: ForwardedRef<T>) => ReactNode, errorComponent?: ComponentType<ErrorComponentProps>) {
   return forwardRef<T, P>(function (props, ref) {
     return (
       <Suspense fallback={fallback?.(ref)}>
-        <Component {...props} ref={ref} />
+        <ErrorBoundary errorComponent={errorComponent}>
+          <Component {...props} ref={ref} />
+        </ErrorBoundary>
       </Suspense>
     );
   });

--- a/packages/widgets/src/widgets/db/sql/remote/Widget.tsx
+++ b/packages/widgets/src/widgets/db/sql/remote/Widget.tsx
@@ -24,8 +24,6 @@ type Visualization = (data: any, theme: any) => { data: CharacterData, options: 
 const Widget = forwardRef<HTMLDivElement, WidgetProps>(function Widget ({ forwardedRef, owner, repo, branch, name, className, ...props }, _ref) {
   const info = { owner, repo, branch, name };
 
-  throw new Error('BOOM')
-
   const { loading, error, result } = useRemoteCollection(info);
   return (
     <div ref={forwardedRef} className={clsx(className, 'overflow-y-auto overflow-x-hidden p-2')} {...props}>

--- a/packages/widgets/src/widgets/db/sql/remote/Widget.tsx
+++ b/packages/widgets/src/widgets/db/sql/remote/Widget.tsx
@@ -24,6 +24,8 @@ type Visualization = (data: any, theme: any) => { data: CharacterData, options: 
 const Widget = forwardRef<HTMLDivElement, WidgetProps>(function Widget ({ forwardedRef, owner, repo, branch, name, className, ...props }, _ref) {
   const info = { owner, repo, branch, name };
 
+  throw new Error('BOOM')
+
   const { loading, error, result } = useRemoteCollection(info);
   return (
     <div ref={forwardedRef} className={clsx(className, 'overflow-y-auto overflow-x-hidden p-2')} {...props}>


### PR DESCRIPTION
close #127 