### PR TITLE
include GitHub Actions workflow files with deploy button

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "version": 2,
   "name": "OSSInsight Lite",
   "framework": "nextjs",
+  "includeFiles": ".github/**",
   "installCommand": "pnpm run next:install"
 }


### PR DESCRIPTION
By default, Vercel excludes the `.github` directory when deploying your project, which includes GitHub Actions workflow files. This is because Vercel handles deployments on its platform, outside of the GitHub Actions infrastructure.

However, if you want to include GitHub Actions workflow files in your Vercel deployment for some reason, there's a workaround by using the `vercel.json` configuration file:

1. Add a `vercel.json` file in the root directory of your project and include the `.github` directory in the `includeFiles` attribute:

```json
{
    "includeFiles": ".github/**"
}
```

+ #124 